### PR TITLE
feat: add url and storage name fields to file model

### DIFF
--- a/prisma/migrations/20250513143342_add_url_and_storage_name/migration.sql
+++ b/prisma/migrations/20250513143342_add_url_and_storage_name/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "File" ADD COLUMN     "storageName" TEXT,
+ADD COLUMN     "url" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,27 +1,29 @@
 generator client {
-  provider = "prisma-client-js"
+    provider = "prisma-client-js"
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+    provider = "postgresql"
+    url      = env("DATABASE_URL")
 }
 
 model File {
-  id             String         @id @default(cuid())
-  name           String
-  size           Int
-  type           String
-  createdAt      DateTime       @default(now())
-  updatedAt      DateTime       @updatedAt
-  deletedAt      DateTime?      @default(now())
-  cloudStorages  CloudStorage[]
+    id            String         @id @default(cuid())
+    name          String
+    size          Int
+    type          String
+    url           String?
+    storageName   String?
+    createdAt     DateTime       @default(now())
+    updatedAt     DateTime       @updatedAt
+    deletedAt     DateTime?      @default(now())
+    cloudStorages CloudStorage[]
 }
 
 model CloudStorage {
-  id        String   @id @default(cuid())
-  provider  String
-  apiKey    String   @db.Text
-  files     File[]
-  createdAt DateTime @default(now())
+    id        String   @id @default(cuid())
+    provider  String
+    apiKey    String   @db.Text
+    files     File[]
+    createdAt DateTime @default(now())
 }

--- a/src/providers/dropbox/dropbox.service.ts
+++ b/src/providers/dropbox/dropbox.service.ts
@@ -158,6 +158,8 @@ export class DropboxService implements CloudStorageProvider {
         name: file.originalname,
         size: file.size,
         type: file.mimetype,
+        url: url,
+        storageName: storageName,
         cloudStorages: {
           create: {
             provider: 'dropbox',

--- a/src/providers/google-cloud/google-cloud.service.ts
+++ b/src/providers/google-cloud/google-cloud.service.ts
@@ -181,6 +181,8 @@ export class GoogleCloudService implements CloudStorageProvider {
         name: file.originalname,
         size: file.size,
         type: file.mimetype,
+        url: url,
+        storageName: storageName,
         cloudStorages: {
           create: {
             provider: 'google',


### PR DESCRIPTION
## Description
This PR adds support for storing file URLs and storage names in the database. Previously, these values were passed to the `saveFileRecord` function but were not persisted, resulting in lost reference information.

## Changes
- Added `url` and `storageName` fields to the `File` model in the Prisma schema
- Updated the `saveFileRecord` functions in both the Dropbox and Google Cloud services to save these values
- Created database migration to add the new fields

## Testing Done
- Verified schema changes with Prisma validation
- Tested file upload flow with both providers
- Confirmed URL and storage name are correctly saved to the database
- Verified backward compatibility with existing records

## Related Issues
Resolves #3 

