### PR TITLE
feat: add google drive as a provider

### DIFF
--- a/get-token.js
+++ b/get-token.js
@@ -1,0 +1,68 @@
+const { google } = require('googleapis');
+const http = require('http');
+const url = require('url');
+const destroyer = require('server-destroy');
+
+async function getRefreshToken() {
+  const CLIENT_ID =
+    '43523055081-fv1mrj4rk1nt78jii3gn40gho6d4frda.apps.googleusercontent.com';
+  const CLIENT_SECRET = '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';
+  const REDIRECT_URI = 'http://localhost:3000/oauth2callback';
+
+  const oauth2Client = new google.auth.OAuth2(
+    CLIENT_ID,
+    CLIENT_SECRET,
+    REDIRECT_URI,
+  );
+
+  const authorizeUrl = oauth2Client.generateAuthUrl({
+    access_type: 'offline',
+    scope: ['https://www.googleapis.com/auth/drive'],
+    prompt: 'consent',
+  });
+
+  console.log('Please open this URL in your browser:');
+  console.log(authorizeUrl);
+
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(async (req, res) => {
+      try {
+        const queryParams = url.parse(req.url, true).query;
+
+        if (queryParams.code) {
+          const { tokens } = await oauth2Client.getToken(queryParams.code);
+
+          res.end('Authentication successful! You can close this tab.');
+
+          server.destroy();
+
+          resolve(tokens);
+        }
+      } catch (e) {
+        reject(e);
+      }
+    });
+
+    server.listen(3000, () => {
+      console.log(
+        'Waiting for authorization on http://localhost:3000/oauth2callback',
+      );
+    });
+
+    destroyer(server);
+  });
+}
+
+getRefreshToken()
+  .then((tokens) => {
+    console.log('\nYour refresh token:');
+    console.log(tokens.refresh_token);
+    console.log('\nAccess token (temporary):');
+    console.log(tokens.access_token);
+    console.log(
+      '\nStore the refresh token securely in your environment variables as GOOGLE_DRIVE_REFRESH_TOKEN',
+    );
+  })
+  .catch((err) => {
+    console.error('Error getting refresh token:', err);
+  });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@google-cloud/storage": "^7.15.0",
+        "@googleapis/drive": "^12.0.0",
         "@nestjs/common": "^11.0.0",
         "@nestjs/config": "^4.0.0",
         "@nestjs/core": "^11.0.0",
@@ -17,9 +18,12 @@
         "@nestjs/swagger": "^11.2.0",
         "@prisma/client": "^6.2.1",
         "dropbox": "^10.34.0",
+        "googleapis": "^148.0.0",
         "megajs": "^1.3.7",
+        "open": "^10.1.2",
         "reflect-metadata": "^0.2.0",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.1",
+        "server-destroy": "^1.0.1"
       },
       "devDependencies": {
         "@nestjs/cli": "^11.0.0",
@@ -1323,6 +1327,18 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@googleapis/drive": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/drive/-/drive-12.0.0.tgz",
+      "integrity": "sha512-bAZ82QKSuvzT4UNuuistEJCGjYCGcDYo2WsZ8S7KmN/gaHs2oz5U07/y/ITbzganqMtvXw7B6YG1f76k7F8+0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -4387,6 +4403,21 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -4995,6 +5026,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/default-browser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -5003,6 +5062,18 @@
       "license": "MIT",
       "dependencies": {
         "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6488,6 +6559,49 @@
         "node": ">=14"
       }
     },
+    "node_modules/googleapis": {
+      "version": "148.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-148.0.0.tgz",
+      "integrity": "sha512-8PDG5VItm6E1TdZWDqtRrUJSlBcNwz0/MwCa6AL81y/RxPGXJRUwKqGZfCoVX1ZBbfr3I4NkDxBmeTyOAZSWqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -6813,6 +6927,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -6854,6 +6983,24 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-interactive": {
@@ -6912,6 +7059,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8526,6 +8688,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.1.2.tgz",
+      "integrity": "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -9388,6 +9568,18 @@
         "node": ">= 18"
       }
     },
+    "node_modules/run-applescript": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -9559,6 +9751,12 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/server-destroy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+      "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==",
+      "license": "ISC"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -10733,6 +10931,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@google-cloud/storage": "^7.15.0",
+    "@googleapis/drive": "^12.0.0",
     "@nestjs/common": "^11.0.0",
     "@nestjs/config": "^4.0.0",
     "@nestjs/core": "^11.0.0",
@@ -28,9 +29,12 @@
     "@nestjs/swagger": "^11.2.0",
     "@prisma/client": "^6.2.1",
     "dropbox": "^10.34.0",
+    "googleapis": "^148.0.0",
     "megajs": "^1.3.7",
+    "open": "^10.1.2",
     "reflect-metadata": "^0.2.0",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "server-destroy": "^1.0.1"
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { DropboxModule } from './providers/dropbox/dropbox.module';
 import { GoogleCloudModule } from './providers/google-cloud/google-cloud.module';
 import { HealthCheckModule } from './health-check/health-check.module';
 import { MegaModule } from './providers/mega/mega.module';
+import { GoogleDriveModule } from './providers/google-drive/google-drive.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { MegaModule } from './providers/mega/mega.module';
     DropboxModule,
     GoogleCloudModule,
     MegaModule,
+    GoogleDriveModule,
     HealthCheckModule,
   ],
   controllers: [AppController],

--- a/src/providers/google-drive/google-drive.module.ts
+++ b/src/providers/google-drive/google-drive.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { GoogleDriveService } from './google-drive.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { EncryptionService } from '../../utils/encryption.util';
+import { ConfigModule } from '@nestjs/config';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [GoogleDriveService, PrismaService, EncryptionService],
+  exports: [GoogleDriveService],
+})
+export class GoogleDriveModule {}

--- a/src/providers/google-drive/google-drive.service.ts
+++ b/src/providers/google-drive/google-drive.service.ts
@@ -1,0 +1,329 @@
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../../prisma/prisma.service';
+import { EncryptionService } from '../../utils/encryption.util';
+import {
+  CloudStorageProvider,
+  FileListItem,
+} from '../../common/interfaces/cloud-storage.interface';
+import { drive_v3 } from '@googleapis/drive';
+import { OAuth2Client } from 'google-auth-library';
+import { google } from 'googleapis';
+import { Readable } from 'stream';
+
+@Injectable()
+export class GoogleDriveService implements CloudStorageProvider {
+  private readonly logger = new Logger(GoogleDriveService.name);
+  private readonly SCOPES = ['https://www.googleapis.com/auth/drive'];
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly prisma: PrismaService,
+    private readonly encryptionService: EncryptionService,
+  ) {}
+
+  private async getDriveClient(): Promise<drive_v3.Drive> {
+    const clientId = this.configService.get<string>('GOOGLE_DRIVE_CLIENT_ID');
+    const clientSecret = this.configService.get<string>(
+      'GOOGLE_DRIVE_CLIENT_SECRET',
+    );
+    const refreshToken = this.configService.get<string>(
+      'GOOGLE_DRIVE_REFRESH_TOKEN',
+    );
+
+    if (!clientId || !clientSecret || !refreshToken) {
+      throw new BadRequestException(
+        'Google Drive API credentials are missing in environment variables.',
+      );
+    }
+
+    try {
+      const auth = new OAuth2Client(clientId, clientSecret);
+      auth.setCredentials({ refresh_token: refreshToken });
+
+      return google.drive({ version: 'v3', auth });
+    } catch (error) {
+      this.logger.error(
+        `Google Drive client initialization error: ${error.message}`,
+      );
+      throw new BadRequestException(
+        `Failed to initialize Google Drive client: ${error.message}`,
+      );
+    }
+  }
+
+  private async getFolderId(
+    folderPath: string,
+    drive: drive_v3.Drive,
+  ): Promise<string> {
+    if (!folderPath) return 'root';
+
+    const folderNames = folderPath.split('/').filter((name) => name.length > 0);
+    let parentId = 'root';
+
+    for (const folderName of folderNames) {
+      const query = `name = '${folderName}' and mimeType = 'application/vnd.google-apps.folder' and '${parentId}' in parents and trashed = false`;
+
+      const response = await drive.files.list({
+        q: query,
+        fields: 'files(id, name)',
+        spaces: 'drive',
+      });
+
+      if (response.data.files && response.data.files.length > 0) {
+        parentId = response.data.files[0].id;
+      } else {
+        const folderMetadata = {
+          name: folderName,
+          mimeType: 'application/vnd.google-apps.folder',
+          parents: [parentId],
+        };
+
+        const folder = await drive.files.create({
+          requestBody: folderMetadata,
+          fields: 'id',
+        });
+
+        parentId = folder.data.id;
+      }
+    }
+
+    return parentId;
+  }
+
+  async uploadFile(
+    file: Express.Multer.File,
+    fileName: string,
+    folderPath?: string,
+  ): Promise<{ url: string; storageName: string }> {
+    try {
+      const drive = await this.getDriveClient();
+      const folderId = await this.getFolderId(folderPath, drive);
+
+      const fileMetadata = {
+        name: fileName,
+        parents: [folderId],
+      };
+
+      const media = {
+        mimeType: file.mimetype,
+        body: Readable.from(file.buffer),
+      };
+
+      const response = await drive.files.create({
+        requestBody: fileMetadata,
+        media: media,
+        fields: 'id,webViewLink',
+      });
+
+      if (!response.data.id) {
+        throw new BadRequestException('Failed to upload file to Google Drive');
+      }
+
+      await drive.permissions.create({
+        fileId: response.data.id,
+        requestBody: {
+          role: 'reader',
+          type: 'anyone',
+        },
+      });
+
+      const fileInfo = await drive.files.get({
+        fileId: response.data.id,
+        fields: 'webViewLink',
+      });
+
+      return {
+        url: fileInfo.data.webViewLink,
+        storageName: fileName,
+      };
+    } catch (error) {
+      this.logger.error(`Google Drive upload error: ${error.message}`);
+      throw new BadRequestException(
+        `Failed to upload file to Google Drive: ${error.message}`,
+      );
+    }
+  }
+
+  async listFiles(folderPath?: string): Promise<FileListItem[]> {
+    try {
+      const drive = await this.getDriveClient();
+      const folderId = await this.getFolderId(folderPath, drive);
+
+      const query = `'${folderId}' in parents and trashed = false`;
+      const response = await drive.files.list({
+        q: query,
+        fields: 'files(id, name, mimeType, size, createdTime, modifiedTime)',
+        spaces: 'drive',
+      });
+
+      if (!response.data.files) {
+        return [];
+      }
+
+      return response.data.files.map((file) => ({
+        name: file.name,
+        size: file.size ? parseInt(file.size) : 'Unknown',
+        contentType: file.mimeType || 'Unknown',
+        created: file.createdTime,
+        updated: file.modifiedTime,
+        path: folderPath ? `${folderPath}/${file.name}` : file.name,
+        isFolder: file.mimeType === 'application/vnd.google-apps.folder',
+      }));
+    } catch (error) {
+      this.logger.error(`Google Drive list files error: ${error.message}`);
+      throw new BadRequestException(
+        `Failed to list files from Google Drive: ${error.message}`,
+      );
+    }
+  }
+
+  async downloadFile(fileId: string, folderPath?: string): Promise<Buffer> {
+    try {
+      const drive = await this.getDriveClient();
+
+      let driveFileId = fileId;
+
+      if (folderPath) {
+        const folderId = await this.getFolderId(folderPath, drive);
+        const query = `name = '${fileId}' and '${folderId}' in parents and trashed = false`;
+
+        const response = await drive.files.list({
+          q: query,
+          fields: 'files(id)',
+          spaces: 'drive',
+        });
+
+        if (response.data.files && response.data.files.length > 0) {
+          driveFileId = response.data.files[0].id;
+        } else {
+          throw new BadRequestException(
+            `File '${fileId}' not found in ${folderPath}`,
+          );
+        }
+      }
+
+      const response = await drive.files.get(
+        {
+          fileId: driveFileId,
+          alt: 'media',
+        },
+        { responseType: 'arraybuffer' },
+      );
+
+      return Buffer.from(response.data as ArrayBuffer);
+    } catch (error) {
+      this.logger.error(`Google Drive download error: ${error.message}`);
+      throw new BadRequestException(
+        `Failed to download file from Google Drive: ${error.message}`,
+      );
+    }
+  }
+
+  async deleteFile(fileId: string, folderPath?: string): Promise<void> {
+    try {
+      const drive = await this.getDriveClient();
+
+      let driveFileId = fileId;
+
+      if (folderPath) {
+        const folderId = await this.getFolderId(folderPath, drive);
+        const query = `name = '${fileId}' and '${folderId}' in parents and trashed = false`;
+
+        const response = await drive.files.list({
+          q: query,
+          fields: 'files(id)',
+          spaces: 'drive',
+        });
+
+        if (response.data.files && response.data.files.length > 0) {
+          driveFileId = response.data.files[0].id;
+        } else {
+          throw new BadRequestException(
+            `File '${fileId}' not found in ${folderPath}`,
+          );
+        }
+      }
+
+      await drive.files.delete({
+        fileId: driveFileId,
+      });
+    } catch (error) {
+      this.logger.error(`Google Drive delete error: ${error.message}`);
+      throw new BadRequestException(
+        `Failed to delete file from Google Drive: ${error.message}`,
+      );
+    }
+  }
+
+  async createFolder(folderPath: string): Promise<void> {
+    try {
+      if (!folderPath) {
+        throw new BadRequestException('Folder path is required');
+      }
+
+      const drive = await this.getDriveClient();
+      await this.getFolderId(folderPath, drive);
+      this.logger.log(`Folder '${folderPath}' created in Google Drive`);
+    } catch (error) {
+      if (error.message?.includes('already exists')) {
+        this.logger.log(
+          `Folder '${folderPath}' already exists in Google Drive`,
+        );
+        return;
+      }
+      this.logger.error(`Google Drive create folder error: ${error.message}`);
+      throw new BadRequestException(
+        `Failed to create folder in Google Drive: ${error.message}`,
+      );
+    }
+  }
+
+  async saveFileRecord(
+    file: Express.Multer.File,
+    url: string,
+    storageName: string,
+    folderPath?: string,
+  ): Promise<string> {
+    const encryptionSecret = this.configService.get('ENCRYPTION_SECRET');
+    if (!encryptionSecret) {
+      throw new BadRequestException(
+        'ENCRYPTION_SECRET is not set in environment variables',
+      );
+    }
+
+    const clientId = this.configService.get('GOOGLE_DRIVE_CLIENT_ID');
+    const clientSecret = this.configService.get('GOOGLE_DRIVE_CLIENT_SECRET');
+    const refreshToken = this.configService.get('GOOGLE_DRIVE_REFRESH_TOKEN');
+
+    if (!clientId || !clientSecret || !refreshToken) {
+      throw new BadRequestException(
+        'Google Drive API credentials are not set in environment variables',
+      );
+    }
+
+    const encryptedCredentials = await this.encryptionService.encrypt(
+      JSON.stringify({ clientId, clientSecret, refreshToken }),
+      encryptionSecret,
+    );
+
+    const savedFile = await this.prisma.file.create({
+      data: {
+        name: file.originalname,
+        size: file.size,
+        type: file.mimetype,
+        url: url,
+        storageName: storageName,
+        path: folderPath,
+        cloudStorages: {
+          create: {
+            provider: 'google-drive',
+            apiKey: encryptedCredentials,
+          },
+        },
+      },
+    });
+
+    return savedFile.id;
+  }
+}

--- a/src/storage/documentation/models/provider.enum.ts
+++ b/src/storage/documentation/models/provider.enum.ts
@@ -4,6 +4,7 @@ export enum StorageProvider {
   GOOGLE = 'google',
   DROPBOX = 'dropbox',
   MEGA = 'mega',
+  GOOGLE_DRIVE = 'google-drive',
 }
 
 export class ProviderParam {

--- a/src/storage/storage.module.ts
+++ b/src/storage/storage.module.ts
@@ -4,9 +4,10 @@ import { StorageService } from './storage.service';
 import { GoogleCloudModule } from '../providers/google-cloud/google-cloud.module';
 import { DropboxModule } from '../providers/dropbox/dropbox.module';
 import { MegaModule } from 'src/providers/mega/mega.module';
+import { GoogleDriveModule } from '../providers/google-drive/google-drive.module';
 
 @Module({
-  imports: [GoogleCloudModule, DropboxModule, MegaModule],
+  imports: [GoogleCloudModule, DropboxModule, MegaModule, GoogleDriveModule],
   controllers: [StorageController],
   providers: [StorageService],
 })

--- a/src/storage/storage.service.ts
+++ b/src/storage/storage.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, BadRequestException } from '@nestjs/common';
 import { GoogleCloudService } from '../providers/google-cloud/google-cloud.service';
 import { DropboxService } from '../providers/dropbox/dropbox.service';
 import { MegaService } from '../providers/mega/mega.service';
+import { GoogleDriveService } from '../providers/google-drive/google-drive.service';
 import {
   FileUploadResult,
   FileListItem,
@@ -15,6 +16,7 @@ export class StorageService {
     private readonly googleCloudService: GoogleCloudService,
     private readonly dropboxService: DropboxService,
     private readonly megaService: MegaService,
+    private readonly googleDriveService: GoogleDriveService,
   ) {}
 
   async uploadFileToProvider(
@@ -78,6 +80,20 @@ export class StorageService {
             folderPath,
           );
           break;
+        case 'google-drive':
+          const googleDriveResult = await this.googleDriveService.uploadFile(
+            file,
+            storageName,
+            folderPath,
+          );
+          url = googleDriveResult.url;
+          fileId = await this.googleDriveService.saveFileRecord(
+            file,
+            url,
+            storageName,
+            folderPath,
+          );
+          break;
         default:
           throw new BadRequestException('Unsupported provider');
       }
@@ -107,6 +123,8 @@ export class StorageService {
           return this.dropboxService.listFiles(folderPath);
         case 'mega':
           return this.megaService.listFiles(folderPath);
+        case 'google-drive':
+          return this.googleDriveService.listFiles(folderPath);
         default:
           throw new BadRequestException('Unsupported provider');
       }
@@ -129,6 +147,8 @@ export class StorageService {
           return await this.dropboxService.downloadFile(fileId, folderPath);
         case 'mega':
           return await this.megaService.downloadFile(fileId, folderPath);
+        case 'google-drive':
+          return await this.googleDriveService.downloadFile(fileId, folderPath);
         default:
           throw new BadRequestException('Unsupported provider');
       }
@@ -151,6 +171,8 @@ export class StorageService {
           return await this.dropboxService.deleteFile(fileId, folderPath);
         case 'mega':
           return await this.megaService.deleteFile(fileId, folderPath);
+        case 'google-drive':
+          return await this.googleDriveService.deleteFile(fileId, folderPath);
         default:
           throw new BadRequestException('Unsupported provider');
       }
@@ -178,6 +200,9 @@ export class StorageService {
           break;
         case 'mega':
           await this.megaService.createFolder(folderPath);
+          break;
+        case 'google-drive':
+          await this.googleDriveService.createFolder(folderPath);
           break;
         default:
           throw new BadRequestException('Unsupported provider');


### PR DESCRIPTION
**Description:**
This PR adds support for Google Drive as a new cloud storage provider in our multi-cloud storage application. The implementation includes:

1. New Google Drive module and service implementing the CloudStorageProvider interface
2. Environment variable configuration for Google Drive credentials
3. Integration with the existing storage service and controller
4. Support for all core operations: upload, download, list, delete, and create folder


**Testing Notes:**
- Requires valid Google Drive refresh token and client credentials in .env
- All operations should be tested with and without folder paths
- Error cases should be tested (invalid credentials, missing files, etc.)