### PR TITLE
feat: add backblaze b2 as a provider

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { GoogleCloudModule } from './providers/google-cloud/google-cloud.module'
 import { HealthCheckModule } from './health-check/health-check.module';
 import { MegaModule } from './providers/mega/mega.module';
 import { GoogleDriveModule } from './providers/google-drive/google-drive.module';
+import { BackblazeModule } from './providers/backblaze/backblaze.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { GoogleDriveModule } from './providers/google-drive/google-drive.module'
     GoogleCloudModule,
     MegaModule,
     GoogleDriveModule,
+    BackblazeModule,
     HealthCheckModule,
   ],
   controllers: [AppController],

--- a/src/providers/backblaze/backblaze.module.ts
+++ b/src/providers/backblaze/backblaze.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { BackblazeService } from './backblaze.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { EncryptionService } from '../../utils/encryption.util';
+import { ConfigModule } from '@nestjs/config';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [BackblazeService, PrismaService, EncryptionService],
+  exports: [BackblazeService],
+})
+export class BackblazeModule {}

--- a/src/providers/backblaze/backblaze.service.ts
+++ b/src/providers/backblaze/backblaze.service.ts
@@ -1,0 +1,503 @@
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../../prisma/prisma.service';
+import { EncryptionService } from '../../utils/encryption.util';
+import {
+  CloudStorageProvider,
+  FileListItem,
+} from '../../common/interfaces/cloud-storage.interface';
+import { FileValidationPipe } from '../../common/pipes/file-validation.pipe';
+import * as crypto from 'crypto';
+
+@Injectable()
+export class BackblazeService implements CloudStorageProvider {
+  private readonly logger = new Logger(BackblazeService.name);
+  private readonly B2_API_URL = 'https://api.backblazeb2.com';
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly prisma: PrismaService,
+    private readonly encryptionService: EncryptionService,
+  ) {}
+
+  private async getAuthToken(): Promise<{
+    authorizationToken: string;
+    apiUrl: string;
+    downloadUrl: string;
+    accountId: string;
+  }> {
+    const keyId = this.configService.get<string>('B2_KEY_ID');
+    const applicationKey = this.configService.get<string>('B2_APPLICATION_KEY');
+
+    if (!keyId || !applicationKey) {
+      throw new BadRequestException(
+        'B2_KEY_ID or B2_APPLICATION_KEY is missing in environment variables.',
+      );
+    }
+
+    const credentials = Buffer.from(`${keyId}:${applicationKey}`).toString(
+      'base64',
+    );
+
+    try {
+      const response = await fetch(
+        `${this.B2_API_URL}/b2api/v2/b2_authorize_account`,
+        {
+          method: 'GET',
+          headers: {
+            Authorization: `Basic ${credentials}`,
+          },
+        },
+      );
+
+      const responseText = await response.text();
+
+      if (!response.ok) {
+        let errorDetails = responseText;
+        try {
+          const errorJson = JSON.parse(responseText);
+          errorDetails = `Code: ${errorJson.code}, Message: ${errorJson.message}`;
+        } catch {
+          // Response is not JSON, use as-is
+        }
+
+        throw new Error(
+          `Authentication failed (${response.status}): ${errorDetails}`,
+        );
+      }
+
+      const data = JSON.parse(responseText);
+      return {
+        authorizationToken: data.authorizationToken,
+        apiUrl: data.apiUrl,
+        downloadUrl: data.downloadUrl,
+        accountId: data.accountId,
+      };
+    } catch (error) {
+      this.logger.error(`B2 authentication error: ${error.message}`);
+      if (
+        error.message.includes('401') ||
+        error.message.includes('unauthorized')
+      ) {
+        throw new BadRequestException(
+          'B2 authentication failed. Please verify your B2_KEY_ID and B2_APPLICATION_KEY are correct.',
+        );
+      }
+      throw new BadRequestException(
+        `Failed to authenticate with B2: ${error.message}`,
+      );
+    }
+  }
+
+  private async getBucketId(): Promise<string> {
+    const bucketName = this.configService.get<string>('B2_BUCKET_NAME');
+    if (!bucketName) {
+      throw new BadRequestException(
+        'B2_BUCKET_NAME is missing in environment variables.',
+      );
+    }
+
+    const { authorizationToken, apiUrl, accountId } = await this.getAuthToken();
+
+    try {
+      this.logger.log('Requesting bucket list from B2...');
+      const response = await fetch(`${apiUrl}/b2api/v2/b2_list_buckets`, {
+        method: 'POST',
+        headers: {
+          Authorization: authorizationToken,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          accountId: accountId,
+          bucketTypes: ['allPrivate', 'allPublic'],
+        }),
+      });
+
+      const responseText = await response.text();
+
+      if (!response.ok) {
+        let errorDetails = responseText;
+        try {
+          const errorJson = JSON.parse(responseText);
+          errorDetails = `Code: ${errorJson.code}, Message: ${errorJson.message}`;
+        } catch {
+          // Response is not JSON, use as-is
+        }
+
+        throw new Error(
+          `List buckets failed (${response.status}): ${errorDetails}`,
+        );
+      }
+
+      const data = JSON.parse(responseText);
+
+      const bucketNames = data.buckets.map((b: any) => b.bucketName);
+
+      const bucket = data.buckets.find((b: any) => b.bucketName === bucketName);
+
+      if (!bucket) {
+        throw new BadRequestException(
+          `Bucket '${bucketName}' not found. Available buckets: ${bucketNames.join(', ')}`,
+        );
+      }
+      return bucket.bucketId;
+    } catch (error) {
+      this.logger.error(`Error getting bucket ID: ${error.message}`);
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
+      throw new BadRequestException(
+        `Failed to get bucket ID: ${error.message}`,
+      );
+    }
+  }
+
+  private async getUploadUrl(bucketId: string): Promise<{
+    uploadUrl: string;
+    authorizationToken: string;
+  }> {
+    const { authorizationToken, apiUrl } = await this.getAuthToken();
+
+    try {
+      const response = await fetch(`${apiUrl}/b2api/v2/b2_get_upload_url`, {
+        method: 'POST',
+        headers: {
+          Authorization: authorizationToken,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ bucketId }),
+      });
+
+      const responseText = await response.text();
+
+      if (!response.ok) {
+        throw new Error(
+          `Get upload URL failed (${response.status}): ${responseText}`,
+        );
+      }
+
+      const data = JSON.parse(responseText);
+      return {
+        uploadUrl: data.uploadUrl,
+        authorizationToken: data.authorizationToken,
+      };
+    } catch (error) {
+      throw new BadRequestException(
+        `Failed to get upload URL: ${error.message}`,
+      );
+    }
+  }
+
+  async uploadFile(
+    file: Express.Multer.File,
+    fileName: string,
+    folderPath?: string,
+  ): Promise<{ url: string; storageName: string }> {
+    try {
+      const bucketId = await this.getBucketId();
+      const { uploadUrl, authorizationToken } =
+        await this.getUploadUrl(bucketId);
+
+      const fullFileName = folderPath ? `${folderPath}/${fileName}` : fileName;
+      const sha1Hash = crypto
+        .createHash('sha1')
+        .update(file.buffer)
+        .digest('hex');
+
+      const response = await fetch(uploadUrl, {
+        method: 'POST',
+        headers: {
+          Authorization: authorizationToken,
+          'X-Bz-File-Name': encodeURIComponent(fullFileName),
+          'Content-Type': file.mimetype || 'application/octet-stream',
+          'Content-Length': file.size.toString(),
+          'X-Bz-Content-Sha1': sha1Hash,
+        },
+        body: file.buffer,
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`HTTP ${response.status}: ${errorText}`);
+      }
+
+      const uploadResult = await response.json();
+      const bucketName = this.configService.get<string>('B2_BUCKET_NAME');
+      const { downloadUrl } = await this.getAuthToken();
+
+      const fileUrl = `${downloadUrl}/file/${bucketName}/${fullFileName}`;
+
+      return {
+        url: fileUrl,
+        storageName: fileName,
+      };
+    } catch (error) {
+      throw new BadRequestException(
+        `Failed to upload file to B2: ${error.message}`,
+      );
+    }
+  }
+
+  async listFiles(folderPath?: string): Promise<FileListItem[]> {
+    try {
+      const bucketId = await this.getBucketId();
+      const { authorizationToken, apiUrl } = await this.getAuthToken();
+
+      const response = await fetch(`${apiUrl}/b2api/v2/b2_list_file_names`, {
+        method: 'POST',
+        headers: {
+          Authorization: authorizationToken,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          bucketId,
+          startFileName: folderPath ? `${folderPath}/` : undefined,
+          prefix: folderPath ? `${folderPath}/` : undefined,
+          maxFileCount: 1000,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`HTTP ${response.status}: ${errorText}`);
+      }
+
+      const data = await response.json();
+
+      return data.files.map((file: any) => ({
+        name: file.fileName.split('/').pop(),
+        size: file.size,
+        contentType:
+          file.contentType || FileValidationPipe.getMimeType(file.fileName),
+        created: new Date(file.uploadTimestamp).toISOString(),
+        updated: new Date(file.uploadTimestamp).toISOString(),
+        path: file.fileName,
+        isFolder: false,
+      }));
+    } catch (error) {
+      throw new BadRequestException(
+        `Failed to list files from B2: ${error.message}`,
+      );
+    }
+  }
+
+  async downloadFile(fileId: string, folderPath?: string): Promise<Buffer> {
+    try {
+      const { authorizationToken, apiUrl } = await this.getAuthToken();
+      const bucketId = await this.getBucketId();
+      const fullFileName = folderPath ? `${folderPath}/${fileId}` : fileId;
+
+      const listResponse = await fetch(
+        `${apiUrl}/b2api/v2/b2_list_file_names`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: authorizationToken,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            bucketId,
+            startFileName: fullFileName,
+            maxFileCount: 1,
+          }),
+        },
+      );
+
+      if (!listResponse.ok) {
+        const errorText = await listResponse.text();
+        throw new Error(`HTTP ${listResponse.status}: ${errorText}`);
+      }
+
+      const listData = await listResponse.json();
+      const fileInfo = listData.files.find(
+        (f: any) => f.fileName === fullFileName,
+      );
+
+      if (!fileInfo) {
+        throw new BadRequestException(`File '${fileId}' not found`);
+      }
+      const downloadResponse = await fetch(
+        `${apiUrl}/b2api/v2/b2_download_file_by_id`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: authorizationToken,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            fileId: fileInfo.fileId,
+          }),
+        },
+      );
+
+      if (!downloadResponse.ok) {
+        const errorText = await downloadResponse.text();
+        throw new Error(`HTTP ${downloadResponse.status}: ${errorText}`);
+      }
+
+      const arrayBuffer = await downloadResponse.arrayBuffer();
+      return Buffer.from(arrayBuffer);
+    } catch (error) {
+      throw new BadRequestException(
+        `Failed to download file from B2: ${error.message}`,
+      );
+    }
+  }
+
+  async deleteFile(fileId: string, folderPath?: string): Promise<void> {
+    try {
+      const { authorizationToken, apiUrl } = await this.getAuthToken();
+      const bucketId = await this.getBucketId();
+      const fullFileName = folderPath ? `${folderPath}/${fileId}` : fileId;
+
+      const listResponse = await fetch(
+        `${apiUrl}/b2api/v2/b2_list_file_names`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: authorizationToken,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            bucketId,
+            startFileName: fullFileName,
+            maxFileCount: 1,
+          }),
+        },
+      );
+
+      if (!listResponse.ok) {
+        const errorText = await listResponse.text();
+        throw new Error(`HTTP ${listResponse.status}: ${errorText}`);
+      }
+
+      const listData = await listResponse.json();
+      const fileInfo = listData.files.find(
+        (f: any) => f.fileName === fullFileName,
+      );
+
+      if (!fileInfo) {
+        throw new BadRequestException(`File '${fileId}' not found`);
+      }
+
+      const deleteResponse = await fetch(
+        `${apiUrl}/b2api/v2/b2_delete_file_version`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: authorizationToken,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            fileId: fileInfo.fileId,
+            fileName: fileInfo.fileName,
+          }),
+        },
+      );
+
+      if (!deleteResponse.ok) {
+        const errorText = await deleteResponse.text();
+        throw new Error(`HTTP ${deleteResponse.status}: ${errorText}`);
+      }
+
+      this.logger.log(`File deleted successfully: ${fullFileName}`);
+    } catch (error) {
+      this.logger.error(`B2 delete error: ${error.message}`);
+      throw new BadRequestException(
+        `Failed to delete file from B2: ${error.message}`,
+      );
+    }
+  }
+
+  async createFolder(folderPath: string): Promise<void> {
+    try {
+      const bucketId = await this.getBucketId();
+      const { uploadUrl, authorizationToken } =
+        await this.getUploadUrl(bucketId);
+
+      const folderMarker = `${folderPath}/.b2_folder_placeholder`;
+      const emptyBuffer = Buffer.from('');
+      const sha1Hash = crypto
+        .createHash('sha1')
+        .update(emptyBuffer)
+        .digest('hex');
+
+      const response = await fetch(uploadUrl, {
+        method: 'POST',
+        headers: {
+          Authorization: authorizationToken,
+          'X-Bz-File-Name': encodeURIComponent(folderMarker),
+          'Content-Type': 'application/octet-stream',
+          'Content-Length': '0',
+          'X-Bz-Content-Sha1': sha1Hash,
+        },
+        body: emptyBuffer,
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        this.logger.error(
+          `B2 create folder response: ${response.status} - ${errorText}`,
+        );
+        throw new Error(`HTTP ${response.status}: ${errorText}`);
+      }
+
+      this.logger.log(`Folder '${folderPath}' created in B2`);
+    } catch (error) {
+      if (error.message?.includes('already exists')) {
+        this.logger.log(`Folder '${folderPath}' already exists in B2`);
+        return;
+      }
+      this.logger.error(`B2 create folder error: ${error.message}`);
+      throw new BadRequestException(
+        `Failed to create folder in B2: ${error.message}`,
+      );
+    }
+  }
+
+  async saveFileRecord(
+    file: Express.Multer.File,
+    url: string,
+    storageName: string,
+    folderPath?: string,
+  ): Promise<string> {
+    const encryptionSecret = this.configService.get('ENCRYPTION_SECRET');
+    if (!encryptionSecret) {
+      throw new BadRequestException(
+        'ENCRYPTION_SECRET is not set in environment variables',
+      );
+    }
+
+    const keyId = this.configService.get('B2_KEY_ID');
+    const applicationKey = this.configService.get('B2_APPLICATION_KEY');
+    if (!keyId || !applicationKey) {
+      throw new BadRequestException(
+        'B2_KEY_ID or B2_APPLICATION_KEY is not set in environment variables',
+      );
+    }
+
+    const encryptedCredentials = await this.encryptionService.encrypt(
+      JSON.stringify({ keyId, applicationKey }),
+      encryptionSecret,
+    );
+
+    const savedFile = await this.prisma.file.create({
+      data: {
+        name: file.originalname,
+        size: file.size,
+        type: file.mimetype,
+        url: url,
+        storageName: storageName,
+        path: folderPath,
+        cloudStorages: {
+          create: {
+            provider: 'backblaze',
+            apiKey: encryptedCredentials,
+          },
+        },
+      },
+    });
+
+    return savedFile.id;
+  }
+}

--- a/src/storage/documentation/models/provider.enum.ts
+++ b/src/storage/documentation/models/provider.enum.ts
@@ -5,6 +5,7 @@ export enum StorageProvider {
   DROPBOX = 'dropbox',
   MEGA = 'mega',
   GOOGLE_DRIVE = 'google-drive',
+  BACKBLAZE = 'backblaze',
 }
 
 export class ProviderParam {

--- a/src/storage/storage.module.ts
+++ b/src/storage/storage.module.ts
@@ -5,9 +5,16 @@ import { GoogleCloudModule } from '../providers/google-cloud/google-cloud.module
 import { DropboxModule } from '../providers/dropbox/dropbox.module';
 import { MegaModule } from 'src/providers/mega/mega.module';
 import { GoogleDriveModule } from '../providers/google-drive/google-drive.module';
+import { BackblazeModule } from 'src/providers/backblaze/backblaze.module';
 
 @Module({
-  imports: [GoogleCloudModule, DropboxModule, MegaModule, GoogleDriveModule],
+  imports: [
+    GoogleCloudModule,
+    DropboxModule,
+    MegaModule,
+    GoogleDriveModule,
+    BackblazeModule,
+  ],
   controllers: [StorageController],
   providers: [StorageService],
 })

--- a/src/storage/storage.service.ts
+++ b/src/storage/storage.service.ts
@@ -3,6 +3,7 @@ import { GoogleCloudService } from '../providers/google-cloud/google-cloud.servi
 import { DropboxService } from '../providers/dropbox/dropbox.service';
 import { MegaService } from '../providers/mega/mega.service';
 import { GoogleDriveService } from '../providers/google-drive/google-drive.service';
+import { BackblazeService } from '../providers/backblaze/backblaze.service';
 import {
   FileUploadResult,
   FileListItem,
@@ -17,6 +18,7 @@ export class StorageService {
     private readonly dropboxService: DropboxService,
     private readonly megaService: MegaService,
     private readonly googleDriveService: GoogleDriveService,
+    private readonly backblazeService: BackblazeService,
   ) {}
 
   async uploadFileToProvider(
@@ -94,6 +96,20 @@ export class StorageService {
             folderPath,
           );
           break;
+        case 'backblaze':
+          const backblazeResult = await this.backblazeService.uploadFile(
+            file,
+            storageName,
+            folderPath,
+          );
+          url = backblazeResult.url;
+          fileId = await this.backblazeService.saveFileRecord(
+            file,
+            url,
+            storageName,
+            folderPath,
+          );
+          break;
         default:
           throw new BadRequestException('Unsupported provider');
       }
@@ -125,6 +141,8 @@ export class StorageService {
           return this.megaService.listFiles(folderPath);
         case 'google-drive':
           return this.googleDriveService.listFiles(folderPath);
+        case 'backblaze':
+          return this.backblazeService.listFiles(folderPath);
         default:
           throw new BadRequestException('Unsupported provider');
       }
@@ -149,6 +167,8 @@ export class StorageService {
           return await this.megaService.downloadFile(fileId, folderPath);
         case 'google-drive':
           return await this.googleDriveService.downloadFile(fileId, folderPath);
+        case 'backblaze':
+          return await this.backblazeService.downloadFile(fileId, folderPath);
         default:
           throw new BadRequestException('Unsupported provider');
       }
@@ -173,6 +193,8 @@ export class StorageService {
           return await this.megaService.deleteFile(fileId, folderPath);
         case 'google-drive':
           return await this.googleDriveService.deleteFile(fileId, folderPath);
+        case 'backblaze':
+          return await this.backblazeService.deleteFile(fileId, folderPath);
         default:
           throw new BadRequestException('Unsupported provider');
       }
@@ -203,6 +225,9 @@ export class StorageService {
           break;
         case 'google-drive':
           await this.googleDriveService.createFolder(folderPath);
+          break;
+        case 'backblaze':
+          await this.backblazeService.createFolder(folderPath);
           break;
         default:
           throw new BadRequestException('Unsupported provider');


### PR DESCRIPTION
**Description:**
This PR adds support for Backblaze B2 as a new cloud storage provider in our multi-cloud storage application. The implementation includes:

1. New Backblaze B2 module and service implementing the CloudStorageProvider interface
2. Environment variable configuration for Backblaze B2 credentials
3. Integration with the existing storage service and controller
4. Support for all core operations: upload, download, list, delete, and create folder


**Testing Notes:**
- Requires valid Backblaze B2 refresh token and client credentials in .env
- All operations should be tested with and without folder paths
- Error cases should be tested (invalid credentials, missing files, etc.)