### PR TITLE
feat: add microsoft onedrive as a provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/platform-express": "^11.0.0",
         "@nestjs/swagger": "^11.2.0",
         "@prisma/client": "^6.2.1",
+        "axios": "^1.9.0",
         "dropbox": "^10.34.0",
         "googleapis": "^148.0.0",
         "megajs": "^1.3.7",
@@ -4093,6 +4094,17 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/axios": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -6126,6 +6138,26 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -9180,6 +9212,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@nestjs/platform-express": "^11.0.0",
     "@nestjs/swagger": "^11.2.0",
     "@prisma/client": "^6.2.1",
+    "axios": "^1.9.0",
     "dropbox": "^10.34.0",
     "googleapis": "^148.0.0",
     "megajs": "^1.3.7",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { HealthCheckModule } from './health-check/health-check.module';
 import { MegaModule } from './providers/mega/mega.module';
 import { GoogleDriveModule } from './providers/google-drive/google-drive.module';
 import { BackblazeModule } from './providers/backblaze/backblaze.module';
+import { OneDriveModule } from './providers/onedrive/onedrive.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { BackblazeModule } from './providers/backblaze/backblaze.module';
     MegaModule,
     GoogleDriveModule,
     BackblazeModule,
+    OneDriveModule,
     HealthCheckModule,
   ],
   controllers: [AppController],

--- a/src/providers/onedrive/onedrive.module.ts
+++ b/src/providers/onedrive/onedrive.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { OneDriveService } from './onedrive.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { EncryptionService } from '../../utils/encryption.util';
+import { ConfigModule } from '@nestjs/config';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [OneDriveService, PrismaService, EncryptionService],
+  exports: [OneDriveService],
+})
+export class OneDriveModule {}

--- a/src/providers/onedrive/onedrive.service.ts
+++ b/src/providers/onedrive/onedrive.service.ts
@@ -1,0 +1,299 @@
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../../prisma/prisma.service';
+import { EncryptionService } from '../../utils/encryption.util';
+import {
+  CloudStorageProvider,
+  FileListItem,
+} from '../../common/interfaces/cloud-storage.interface';
+import { FileValidationPipe } from '../../common/pipes/file-validation.pipe';
+import axios from 'axios';
+
+@Injectable()
+export class OneDriveService implements CloudStorageProvider {
+  private readonly logger = new Logger(OneDriveService.name);
+  private readonly baseUrl = 'https://graph.microsoft.com/v1.0/me/drive';
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly prisma: PrismaService,
+    private readonly encryptionService: EncryptionService,
+  ) {}
+
+  private async getAccessToken(): Promise<string> {
+    const clientId = this.configService.get<string>('ONEDRIVE_CLIENT_ID');
+    const clientSecret = this.configService.get<string>(
+      'ONEDRIVE_CLIENT_SECRET',
+    );
+    const refreshToken = this.configService.get<string>(
+      'ONEDRIVE_REFRESH_TOKEN',
+    );
+    const tenantId =
+      this.configService.get<string>('ONEDRIVE_TENANT_ID') || 'common';
+
+    if (!clientId || !clientSecret || !refreshToken) {
+      throw new BadRequestException(
+        'OneDrive credentials are missing in environment variables.',
+      );
+    }
+
+    try {
+      const tokenUrl = `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`;
+
+      const params = new URLSearchParams({
+        client_id: clientId,
+        client_secret: clientSecret,
+        refresh_token: refreshToken,
+        grant_type: 'refresh_token',
+        scope: 'https://graph.microsoft.com/Files.ReadWrite.All offline_access',
+      });
+
+      const response = await axios.post(tokenUrl, params, {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+      });
+
+      return response.data.access_token;
+    } catch (error) {
+      this.logger.error(`OneDrive token refresh error: ${error.message}`);
+      throw new BadRequestException(
+        `Failed to refresh OneDrive access token: ${error.message}`,
+      );
+    }
+  }
+
+  private async getApiHeaders(): Promise<{ Authorization: string }> {
+    const accessToken = await this.getAccessToken();
+    return {
+      Authorization: `Bearer ${accessToken}`,
+    };
+  }
+
+  private async ensureFolderExists(folderPath: string): Promise<void> {
+    if (!folderPath) return;
+
+    const headers = await this.getApiHeaders();
+    const folders = folderPath.split('/').filter((f) => f);
+    let currentPath = '';
+
+    for (const folder of folders) {
+      const parentPath = currentPath ? `${currentPath}/${folder}` : folder;
+
+      try {
+        await axios.get(`${this.baseUrl}/root:/${parentPath}`, { headers });
+        this.logger.log(`Folder '${parentPath}' already exists`);
+      } catch (error) {
+        if (error.response?.status === 404) {
+          const createUrl = currentPath
+            ? `${this.baseUrl}/root:/${currentPath}:/children`
+            : `${this.baseUrl}/root/children`;
+
+          await axios.post(
+            createUrl,
+            {
+              name: folder,
+              folder: {},
+              '@microsoft.graph.conflictBehavior': 'rename',
+            },
+            { headers },
+          );
+          this.logger.log(`Created folder '${parentPath}'`);
+        } else {
+          throw error;
+        }
+      }
+
+      currentPath = parentPath;
+    }
+  }
+
+  async uploadFile(
+    file: Express.Multer.File,
+    fileName: string,
+    folderPath?: string,
+  ): Promise<{ url: string; storageName: string }> {
+    try {
+      await this.ensureFolderExists(folderPath);
+      const headers = await this.getApiHeaders();
+
+      const uploadPath = folderPath
+        ? `${this.baseUrl}/root:/${folderPath}/${fileName}:/content`
+        : `${this.baseUrl}/root:/${fileName}:/content`;
+
+      this.logger.log(`Uploading file '${fileName}' to OneDrive...`);
+
+      const uploadResponse = await axios.put(uploadPath, file.buffer, {
+        headers: {
+          ...headers,
+          'Content-Type': 'application/octet-stream',
+        },
+      });
+
+      const shareUrl = `${this.baseUrl}/items/${uploadResponse.data.id}/createLink`;
+      const shareResponse = await axios.post(
+        shareUrl,
+        {
+          type: 'view',
+          scope: 'anonymous',
+        },
+        { headers },
+      );
+
+      this.logger.log(`File uploaded successfully: ${fileName}`);
+
+      return {
+        url: shareResponse.data.link.webUrl,
+        storageName: fileName,
+      };
+    } catch (error) {
+      this.logger.error(`OneDrive upload error: ${error.message}`);
+      throw new BadRequestException(
+        `Failed to upload file to OneDrive: ${error.message}`,
+      );
+    }
+  }
+
+  async listFiles(folderPath?: string): Promise<FileListItem[]> {
+    try {
+      const headers = await this.getApiHeaders();
+
+      const listUrl = folderPath
+        ? `${this.baseUrl}/root:/${folderPath}:/children`
+        : `${this.baseUrl}/root/children`;
+
+      const response = await axios.get(listUrl, { headers });
+
+      return response.data.value.map((item: any) => ({
+        name: item.name,
+        size: item.folder ? '-' : item.size.toString(),
+        contentType: item.folder
+          ? 'folder'
+          : FileValidationPipe.getMimeType(item.name),
+        created: item.createdDateTime,
+        updated: item.lastModifiedDateTime,
+        path: folderPath ? `${folderPath}/${item.name}` : item.name,
+        isFolder: !!item.folder,
+      }));
+    } catch (error) {
+      this.logger.error(`OneDrive list files error: ${error.message}`);
+      throw new BadRequestException(
+        `Failed to list files from OneDrive: ${error.message}`,
+      );
+    }
+  }
+
+  async downloadFile(fileId: string, folderPath?: string): Promise<Buffer> {
+    try {
+      const headers = await this.getApiHeaders();
+
+      const filePath = folderPath
+        ? `${this.baseUrl}/root:/${folderPath}/${fileId}:/content`
+        : `${this.baseUrl}/root:/${fileId}:/content`;
+
+      const response = await axios.get(filePath, {
+        headers,
+        responseType: 'arraybuffer',
+      });
+
+      return Buffer.from(response.data);
+    } catch (error) {
+      this.logger.error(`OneDrive download error: ${error.message}`);
+      throw new BadRequestException(
+        `Failed to download file from OneDrive: ${error.message}`,
+      );
+    }
+  }
+
+  async deleteFile(fileId: string, folderPath?: string): Promise<void> {
+    try {
+      const headers = await this.getApiHeaders();
+
+      const filePath = folderPath
+        ? `${this.baseUrl}/root:/${folderPath}/${fileId}`
+        : `${this.baseUrl}/root:/${fileId}`;
+
+      await axios.delete(filePath, { headers });
+      this.logger.log(`File '${fileId}' deleted successfully from OneDrive`);
+    } catch (error) {
+      this.logger.error(`OneDrive delete error: ${error.message}`);
+      throw new BadRequestException(
+        `Failed to delete file from OneDrive: ${error.message}`,
+      );
+    }
+  }
+
+  async createFolder(folderPath: string): Promise<void> {
+    try {
+      if (!folderPath) {
+        throw new BadRequestException('Folder path is required');
+      }
+
+      await this.ensureFolderExists(folderPath);
+      this.logger.log(`Folder '${folderPath}' created in OneDrive`);
+    } catch (error) {
+      if (error.message?.includes('already exists')) {
+        this.logger.log(`Folder '${folderPath}' already exists in OneDrive`);
+        return;
+      }
+      this.logger.error(`OneDrive create folder error: ${error.message}`);
+      throw new BadRequestException(
+        `Failed to create folder in OneDrive: ${error.message}`,
+      );
+    }
+  }
+
+  async saveFileRecord(
+    file: Express.Multer.File,
+    url: string,
+    storageName: string,
+    folderPath?: string,
+  ): Promise<string> {
+    const encryptionSecret = this.configService.get('ENCRYPTION_SECRET');
+    if (!encryptionSecret) {
+      throw new BadRequestException(
+        'ENCRYPTION_SECRET is not set in environment variables',
+      );
+    }
+
+    const clientId = this.configService.get('ONEDRIVE_CLIENT_ID');
+    const clientSecret = this.configService.get('ONEDRIVE_CLIENT_SECRET');
+    const refreshToken = this.configService.get('ONEDRIVE_REFRESH_TOKEN');
+    const tenantId = this.configService.get('ONEDRIVE_TENANT_ID');
+
+    if (!clientId || !clientSecret || !refreshToken) {
+      throw new BadRequestException(
+        'OneDrive credentials are not set in environment variables',
+      );
+    }
+
+    const encryptedCredentials = await this.encryptionService.encrypt(
+      JSON.stringify({
+        clientId,
+        clientSecret,
+        refreshToken,
+        tenantId,
+      }),
+      encryptionSecret,
+    );
+
+    const savedFile = await this.prisma.file.create({
+      data: {
+        name: file.originalname,
+        size: file.size,
+        type: file.mimetype,
+        url: url,
+        storageName: storageName,
+        path: folderPath,
+        cloudStorages: {
+          create: {
+            provider: 'onedrive',
+            apiKey: encryptedCredentials,
+          },
+        },
+      },
+    });
+
+    return savedFile.id;
+  }
+}

--- a/src/storage/documentation/models/provider.enum.ts
+++ b/src/storage/documentation/models/provider.enum.ts
@@ -6,6 +6,7 @@ export enum StorageProvider {
   MEGA = 'mega',
   GOOGLE_DRIVE = 'google-drive',
   BACKBLAZE = 'backblaze',
+  ONEDRIVE = 'onedrive',
 }
 
 export class ProviderParam {

--- a/src/storage/storage.module.ts
+++ b/src/storage/storage.module.ts
@@ -6,6 +6,7 @@ import { DropboxModule } from '../providers/dropbox/dropbox.module';
 import { MegaModule } from 'src/providers/mega/mega.module';
 import { GoogleDriveModule } from '../providers/google-drive/google-drive.module';
 import { BackblazeModule } from 'src/providers/backblaze/backblaze.module';
+import { OneDriveModule } from 'src/providers/onedrive/onedrive.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { BackblazeModule } from 'src/providers/backblaze/backblaze.module';
     MegaModule,
     GoogleDriveModule,
     BackblazeModule,
+    OneDriveModule,
   ],
   controllers: [StorageController],
   providers: [StorageService],

--- a/src/storage/storage.service.ts
+++ b/src/storage/storage.service.ts
@@ -4,6 +4,7 @@ import { DropboxService } from '../providers/dropbox/dropbox.service';
 import { MegaService } from '../providers/mega/mega.service';
 import { GoogleDriveService } from '../providers/google-drive/google-drive.service';
 import { BackblazeService } from '../providers/backblaze/backblaze.service';
+import { OneDriveService } from '../providers/onedrive/onedrive.service';
 import {
   FileUploadResult,
   FileListItem,
@@ -19,6 +20,7 @@ export class StorageService {
     private readonly megaService: MegaService,
     private readonly googleDriveService: GoogleDriveService,
     private readonly backblazeService: BackblazeService,
+    private readonly oneDriveService: OneDriveService,
   ) {}
 
   async uploadFileToProvider(
@@ -110,6 +112,20 @@ export class StorageService {
             folderPath,
           );
           break;
+        case 'onedrive':
+          const oneDriveResult = await this.oneDriveService.uploadFile(
+            file,
+            storageName,
+            folderPath,
+          );
+          url = oneDriveResult.url;
+          fileId = await this.oneDriveService.saveFileRecord(
+            file,
+            url,
+            storageName,
+            folderPath,
+          );
+          break;
         default:
           throw new BadRequestException('Unsupported provider');
       }
@@ -143,6 +159,8 @@ export class StorageService {
           return this.googleDriveService.listFiles(folderPath);
         case 'backblaze':
           return this.backblazeService.listFiles(folderPath);
+        case 'onedrive':
+          return this.oneDriveService.listFiles(folderPath);
         default:
           throw new BadRequestException('Unsupported provider');
       }
@@ -169,6 +187,8 @@ export class StorageService {
           return await this.googleDriveService.downloadFile(fileId, folderPath);
         case 'backblaze':
           return await this.backblazeService.downloadFile(fileId, folderPath);
+        case 'onedrive':
+          return await this.oneDriveService.downloadFile(fileId, folderPath);
         default:
           throw new BadRequestException('Unsupported provider');
       }
@@ -195,6 +215,8 @@ export class StorageService {
           return await this.googleDriveService.deleteFile(fileId, folderPath);
         case 'backblaze':
           return await this.backblazeService.deleteFile(fileId, folderPath);
+        case 'onedrive':
+          return await this.oneDriveService.deleteFile(fileId, folderPath);
         default:
           throw new BadRequestException('Unsupported provider');
       }
@@ -228,6 +250,9 @@ export class StorageService {
           break;
         case 'backblaze':
           await this.backblazeService.createFolder(folderPath);
+          break;
+        case 'onedrive':
+          await this.oneDriveService.createFolder(folderPath);
           break;
         default:
           throw new BadRequestException('Unsupported provider');


### PR DESCRIPTION
**Description:**
This PR adds support for Google Drive as a new cloud storage provider in our multi-cloud storage application. The implementation includes:

1. New Onedrive module and service implementing the CloudStorageProvider interface
2. Environment variable configuration for Onedrive credentials
3. Integration with the existing storage service and controller
4. Support for all core operations: upload, download, list, delete, and create folder


**Testing Notes:**
- Requires valid Onedrive refresh token and client credentials in .env
- All operations should be tested with and without folder paths
- Error cases should be tested (invalid credentials, missing files, etc.)